### PR TITLE
SAKAI-2640 Add blank line after forms by default

### DIFF
--- a/tool/src/webapp/css/attendance.css
+++ b/tool/src/webapp/css/attendance.css
@@ -18,6 +18,10 @@ body {
     color: #111;
 }
 
+form {
+    margin-bottom: 1em;
+}
+
 /* style the Wicket FeedbackPanel to remove the list */
 .alertMessage ul, .messageSuccess ul {
     list-style-type: none !important;


### PR DESCRIPTION
Unstyled forms in the attendance tool should have a blank line after
them by default. Specific forms that require different styling can
override this blank line.